### PR TITLE
🚀 Update to Discord Components V2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.6.1</version>
+            <version>6.1.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
             <version>2.0.12</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.5.15</version>

--- a/src/main/java/ofc/bot/commands/slash/NamesHistoryCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/NamesHistoryCommand.java
@@ -1,6 +1,7 @@
 package ofc.bot.commands.slash;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
@@ -8,7 +9,6 @@ import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.enums.NameScope;
 import ofc.bot.domain.sqlite.repository.UserNameUpdateRepository;
 import ofc.bot.domain.viewmodels.NamesHistoryView;
@@ -54,7 +54,7 @@ public class NamesHistoryCommand extends SlashCommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(buttons)
+                .setActionRows(buttons)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/OpenTicketCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/OpenTicketCommand.java
@@ -3,7 +3,7 @@ package ofc.bot.commands.slash;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.modals.Modal;
 import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.Cooldown;
 import ofc.bot.handlers.interactions.commands.contexts.impl.SlashCommandContext;

--- a/src/main/java/ofc/bot/commands/slash/ViewTicketCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/ViewTicketCommand.java
@@ -2,12 +2,12 @@ package ofc.bot.commands.slash;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.Main;
 import ofc.bot.domain.entity.SupportTicket;
 import ofc.bot.domain.sqlite.repository.MessageVersionRepository;
@@ -63,7 +63,7 @@ public class ViewTicketCommand extends SlashCommand {
 
             ctx.create()
                     .setEmbeds(embed)
-                    .setActionRow(buttons)
+                    .setActionRows(buttons)
                     .send();
         }, (err) -> { // ????????
             LOGGER.error("We somehow did not find the user who issued the ticket for id #{}", ticket.getId(), err);

--- a/src/main/java/ofc/bot/commands/slash/additionals/AdditionalRolesCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/additionals/AdditionalRolesCommand.java
@@ -1,12 +1,12 @@
 package ofc.bot.commands.slash.additionals;
 
+import net.dv8tion.jda.api.components.selections.SelectMenu;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
-import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.modals.Modal;
 import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.contexts.impl.SlashCommandContext;
 import ofc.bot.handlers.interactions.commands.responses.states.InteractionResult;

--- a/src/main/java/ofc/bot/commands/slash/bets/BetTicTacToeCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/bets/BetTicTacToeCommand.java
@@ -1,10 +1,10 @@
 package ofc.bot.commands.slash.bets;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.sqlite.repository.UserEconomyRepository;
 import ofc.bot.handlers.games.betting.BetManager;
 import ofc.bot.handlers.games.betting.tictactoe.TicTacToeGame;
@@ -53,7 +53,7 @@ public class BetTicTacToeCommand extends SlashSubcommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(accept)
+                .setActionRows(accept)
                 .setContent(Status.USER_INVITING_TO_TICTACTOE.args(member.getAsMention()))
                 .send();
     }

--- a/src/main/java/ofc/bot/commands/slash/birthday/BirthdaysCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/birthday/BirthdaysCommand.java
@@ -1,12 +1,12 @@
 package ofc.bot.commands.slash.birthday;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.Birthday;
 import ofc.bot.domain.sqlite.repository.BirthdayRepository;
 import ofc.bot.handlers.interactions.EntityContextFactory;
@@ -42,7 +42,7 @@ public class BirthdaysCommand extends SlashCommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(buttons)
+                .setActionRows(buttons)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/economy/LeaderboardCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/economy/LeaderboardCommand.java
@@ -1,12 +1,12 @@
 package ofc.bot.commands.slash.economy;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.sqlite.repository.UserEconomyRepository;
 import ofc.bot.domain.viewmodels.LeaderboardUser;
 import ofc.bot.handlers.interactions.EntityContextFactory;
@@ -52,7 +52,7 @@ public class LeaderboardCommand extends SlashCommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(buttons)
+                .setActionRows(buttons)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/economy/TransactionsCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/economy/TransactionsCommand.java
@@ -1,12 +1,12 @@
 package ofc.bot.commands.slash.economy;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.BankTransaction;
 import ofc.bot.domain.entity.enums.TransactionType;
 import ofc.bot.handlers.economy.CurrencyType;
@@ -51,7 +51,7 @@ public class TransactionsCommand extends SlashCommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(btns)
+                .setActionRows(btns)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/economy/WorkCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/economy/WorkCommand.java
@@ -1,8 +1,8 @@
 package ofc.bot.commands.slash.economy;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.BankTransaction;
 import ofc.bot.domain.entity.UserEconomy;
 import ofc.bot.domain.entity.enums.TransactionType;
@@ -47,7 +47,7 @@ public class WorkCommand extends SlashCommand {
         if (nextWorkAt > now) {
             return ctx.create(true)
                     .setContentFormat("Você poderá trabalhar de novo <t:%s:R>.", nextWorkAt)
-                    .setActionRow(getReminderButton())
+                    .setActionRows(getReminderButton())
                     .send(Status.WAIT_BEFORE_WORK_AGAIN);
         }
 

--- a/src/main/java/ofc/bot/commands/slash/groups/CreateGroupCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/CreateGroupCommand.java
@@ -1,12 +1,12 @@
 package ofc.bot.commands.slash.groups;
 
 import com.vdurmont.emoji.EmojiManager;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.entity.enums.RentStatus;
 import ofc.bot.domain.entity.enums.StoreItemType;
@@ -87,7 +87,7 @@ public class CreateGroupCommand extends SlashSubcommand {
         Button confirmButton = EntityContextFactory.createGroupConfirm(group, color);
         MessageEmbed embed = EmbedFactory.embedGroupCreate(issuer, group, color);
         return ctx.create()
-                .setActionRow(confirmButton)
+                .setActionRows(confirmButton)
                 .setEmbeds(embed)
                 .send();
     }

--- a/src/main/java/ofc/bot/commands/slash/groups/GroupBotsCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/GroupBotsCommand.java
@@ -1,12 +1,12 @@
 package ofc.bot.commands.slash.groups;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.GroupBot;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.entity.enums.StoreItemType;
@@ -58,7 +58,7 @@ public class GroupBotsCommand extends SlashSubcommand {
         Button confirm = EntityContextFactory.createGroupBotAddConfirm(group, bot, price);
         MessageEmbed embed = EmbedFactory.embedGroupBotAdd(issuer, group, bot, price);
         return ctx.create()
-                .setActionRow(confirm)
+                .setActionRows(confirm)
                 .setEmbeds(embed)
                 .send();
     }

--- a/src/main/java/ofc/bot/commands/slash/groups/GroupPayInvoiceCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/GroupPayInvoiceCommand.java
@@ -1,8 +1,8 @@
 package ofc.bot.commands.slash.groups;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.entity.enums.RentStatus;
 import ofc.bot.domain.sqlite.repository.OficinaGroupRepository;
@@ -47,7 +47,7 @@ public class GroupPayInvoiceCommand extends SlashSubcommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(confirm)
+                .setActionRows(confirm)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/groups/GroupPermissionCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/GroupPermissionCommand.java
@@ -1,11 +1,11 @@
 package ofc.bot.commands.slash.groups;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.entity.enums.GroupPermission;
 import ofc.bot.domain.entity.enums.StoreItemType;
@@ -59,7 +59,7 @@ public class GroupPermissionCommand extends SlashSubcommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(confirm)
+                .setActionRows(confirm)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/groups/GroupPinsCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/GroupPinsCommand.java
@@ -1,5 +1,6 @@
 package ofc.bot.commands.slash.groups;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -7,7 +8,6 @@ import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.entity.enums.StoreItemType;
 import ofc.bot.domain.sqlite.repository.OficinaGroupRepository;
@@ -64,7 +64,7 @@ public class GroupPinsCommand extends SlashSubcommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(confirm)
+                .setActionRows(confirm)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/groups/ModifyGroupCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/ModifyGroupCommand.java
@@ -1,11 +1,11 @@
 package ofc.bot.commands.slash.groups;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.entity.enums.StoreItemType;
 import ofc.bot.domain.sqlite.repository.OficinaGroupRepository;
@@ -65,7 +65,7 @@ public class ModifyGroupCommand extends SlashSubcommand {
         Button confirmButton = EntityContextFactory.createModifyGroupConfirm(group, newName, newColor, price);
         MessageEmbed embed = EmbedFactory.embedGroupModify(issuer, group, newName, newColor, price);
         return ctx.create()
-                .setActionRow(confirmButton)
+                .setActionRows(confirmButton)
                 .setEmbeds(embed)
                 .send();
     }

--- a/src/main/java/ofc/bot/commands/slash/groups/channel/CreateGroupChannelCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/channel/CreateGroupChannelCommand.java
@@ -1,12 +1,12 @@
 package ofc.bot.commands.slash.groups.channel;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.entity.enums.StoreItemType;
 import ofc.bot.domain.sqlite.repository.OficinaGroupRepository;
@@ -58,7 +58,7 @@ public class CreateGroupChannelCommand extends SlashSubcommand {
         Button confirm = EntityContextFactory.createGroupChannelConfirm(group, chanType, price);
         MessageEmbed embed = EmbedFactory.embedGroupChannelCreate(issuer, group, chanType, price);
         return ctx.create()
-                .setActionRow(confirm)
+                .setActionRows(confirm)
                 .setEmbeds(embed)
                 .send();
     }

--- a/src/main/java/ofc/bot/commands/slash/groups/member/AddGroupMemberCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/member/AddGroupMemberCommand.java
@@ -1,10 +1,10 @@
 package ofc.bot.commands.slash.groups.member;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.entity.enums.StoreItemType;
 import ofc.bot.domain.sqlite.repository.OficinaGroupRepository;
@@ -62,7 +62,7 @@ public class AddGroupMemberCommand extends SlashSubcommand {
         Button confirm = EntityContextFactory.createAddGroupMemberConfirm(group, newMember, price);
         MessageEmbed embed = EmbedFactory.embedGroupMemberAdd(issuer, group, newMember, price);
         return ctx.create()
-                .setActionRow(confirm)
+                .setActionRows(confirm)
                 .setEmbeds(embed)
                 .send();
     }

--- a/src/main/java/ofc/bot/commands/slash/groups/member/RemoveGroupMemberCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/groups/member/RemoveGroupMemberCommand.java
@@ -1,11 +1,11 @@
 package ofc.bot.commands.slash.groups.member;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.OficinaGroup;
 import ofc.bot.domain.sqlite.repository.OficinaGroupRepository;
 import ofc.bot.handlers.interactions.EntityContextFactory;
@@ -49,7 +49,7 @@ public class RemoveGroupMemberCommand extends SlashSubcommand {
         Button confirm = EntityContextFactory.createRemoveGroupMemberConfirm(group, member.getIdLong());
         MessageEmbed embed = EmbedFactory.embedGroupMemberRemove(issuer, group, member);
         return ctx.create(true)
-                .setActionRow(confirm)
+                .setActionRows(confirm)
                 .setEmbeds(embed)
                 .send();
     }

--- a/src/main/java/ofc/bot/commands/slash/levels/LevelsCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/levels/LevelsCommand.java
@@ -1,11 +1,11 @@
 package ofc.bot.commands.slash.levels;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.sqlite.repository.UserXPRepository;
 import ofc.bot.domain.viewmodels.LevelView;
 import ofc.bot.handlers.interactions.EntityContextFactory;
@@ -50,7 +50,7 @@ public class LevelsCommand extends SlashCommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(buttons)
+                .setActionRows(buttons)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/levels/RankCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/levels/RankCommand.java
@@ -38,8 +38,7 @@ public class RankCommand extends SlashCommand {
 
     @Override
     public InteractionResult onCommand(@NotNull SlashCommandContext ctx) {
-        Member issuer = ctx.getIssuer();
-        Member target = ctx.getOption("member", issuer, OptionMapping::getAsMember);
+        Member target = ctx.getOption("member", OptionMapping::getAsMember);
 
         if (target == null)
             return Status.USER_NOT_FOUND;

--- a/src/main/java/ofc/bot/commands/slash/moderation/InfractionsCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/moderation/InfractionsCommand.java
@@ -1,13 +1,13 @@
 package ofc.bot.commands.slash.moderation;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.MemberPunishment;
 import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.contexts.impl.SlashCommandContext;
@@ -47,7 +47,7 @@ public class InfractionsCommand extends SlashCommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(btns)
+                .setActionRows(btns)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/relationships/marriages/ProposalsListCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/relationships/marriages/ProposalsListCommand.java
@@ -1,12 +1,12 @@
 package ofc.bot.commands.slash.relationships.marriages;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.sqlite.repository.MarriageRequestRepository;
 import ofc.bot.domain.viewmodels.ProposalsView;
 import ofc.bot.handlers.interactions.EntityContextFactory;
@@ -45,7 +45,7 @@ public class ProposalsListCommand extends SlashSubcommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(buttons)
+                .setActionRows(buttons)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/commands/slash/reminders/ListRemindersCommand.java
+++ b/src/main/java/ofc/bot/commands/slash/reminders/ListRemindersCommand.java
@@ -1,11 +1,11 @@
 package ofc.bot.commands.slash.reminders;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.Reminder;
 import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.contexts.impl.SlashCommandContext;
@@ -39,7 +39,7 @@ public class ListRemindersCommand extends SlashSubcommand {
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(buttons)
+                .setActionRows(buttons)
                 .send();
     }
 

--- a/src/main/java/ofc/bot/handlers/games/betting/tictactoe/TicTacToeGame.java
+++ b/src/main/java/ofc/bot/handlers/games/betting/tictactoe/TicTacToeGame.java
@@ -3,13 +3,13 @@ package ofc.bot.handlers.games.betting.tictactoe;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.audit.ActionType;
 import net.dv8tion.jda.api.audit.AuditLogEntry;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.message.MessageDeleteEvent;
 import net.dv8tion.jda.api.exceptions.ErrorHandler;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.internal.utils.Checks;
 import ofc.bot.domain.entity.*;
@@ -125,7 +125,7 @@ public class TicTacToeGame implements Bet<Character> {
         api.retrieveUserById(currentPlayerId).queue(user -> {
             MessageEmbed embed = EmbedFactory.embedTicTacToeGame(user);
             List<ActionRow> rows = Stream.of(EntityContextFactory.createTicTacToeTable(id, currentPlayerId, grid))
-                    .map(ActionRow::of)
+                    .map(btns -> ActionRow.of(List.of(btns)))
                     .toList();
 
             message.editMessageEmbeds(embed)
@@ -393,7 +393,7 @@ public class TicTacToeGame implements Bet<Character> {
             User curr = api.retrieveUserById(currentPlayerId).complete();
             MessageEmbed embed = EmbedFactory.embedTicTacToeGame(curr);
             List<ActionRow> rows = Stream.of(EntityContextFactory.createTicTacToeTable(id, currentPlayerId, grid))
-                    .map(ActionRow::of)
+                    .map(btns -> ActionRow.of(List.of(btns)))
                     .toList();
 
             scheduler.reset();

--- a/src/main/java/ofc/bot/handlers/interactions/actions/AcknowledgeableAction.java
+++ b/src/main/java/ofc/bot/handlers/interactions/actions/AcknowledgeableAction.java
@@ -3,7 +3,7 @@ package ofc.bot.handlers.interactions.actions;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.interactions.Interaction;
-import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.modals.Modal;
 import net.dv8tion.jda.api.utils.FileUpload;
 import ofc.bot.handlers.interactions.commands.responses.InteractionResponseBuilder;
 import ofc.bot.handlers.interactions.commands.responses.InteractionResponseData;

--- a/src/main/java/ofc/bot/handlers/interactions/actions/impl/GenericInteractionRepliableAction.java
+++ b/src/main/java/ofc/bot/handlers/interactions/actions/impl/GenericInteractionRepliableAction.java
@@ -5,7 +5,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.callbacks.IModalCallback;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
-import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.modals.Modal;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.internal.utils.Checks;
 import ofc.bot.handlers.interactions.actions.AcknowledgeableAction;

--- a/src/main/java/ofc/bot/handlers/interactions/buttons/contexts/ButtonClickContext.java
+++ b/src/main/java/ofc/bot/handlers/interactions/buttons/contexts/ButtonClickContext.java
@@ -1,16 +1,14 @@
 package ofc.bot.handlers.interactions.buttons.contexts;
 
+import net.dv8tion.jda.api.components.MessageTopLevelComponent;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.replacer.ComponentReplacer;
+import net.dv8tion.jda.api.components.tree.MessageComponentTree;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.LayoutComponent;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonInteraction;
 import net.dv8tion.jda.api.requests.restaction.MessageEditAction;
 import ofc.bot.handlers.interactions.InteractionSubmitContext;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class ButtonClickContext extends InteractionSubmitContext<ButtonContext, ButtonInteraction> {
 
@@ -33,14 +31,17 @@ public class ButtonClickContext extends InteractionSubmitContext<ButtonContext, 
      * Disables the button the user has clicked.
      */
     public void disable() {
-        List<Button> buttons = new ArrayList<>(getMessage().getButtons());
-        int btnIndex = findTargetButtonIndex();
+        ButtonInteraction source = getSource();
+        Button clicked = source.getButton();
+        Message msg = getMessage();
+        MessageComponentTree components = msg.getComponentTree();
 
-        Button button = buttons.get(btnIndex);
-        buttons.set(btnIndex, button.asDisabled());
+        ComponentReplacer replacer = ComponentReplacer.byUniqueId(clicked.getUniqueId(),
+                clicked.asDisabled()
+        );
 
-        editMessageComponents(ActionRow.of(buttons))
-                .queue();
+        MessageComponentTree updated = components.replace(replacer);
+        msg.editMessageComponents(updated).queue();
     }
 
     public MessageEditAction editMessage(String content) {
@@ -51,21 +52,11 @@ public class ButtonClickContext extends InteractionSubmitContext<ButtonContext, 
         return getMessage().editMessageEmbeds(embeds);
     }
 
-    public MessageEditAction editMessageComponents(LayoutComponent... components) {
+    public MessageEditAction editMessageComponents(MessageTopLevelComponent... components) {
         return getMessage().editMessageComponents(components);
     }
 
     public Message getMessage() {
         return getSource().getMessage();
-    }
-
-    private int findTargetButtonIndex() {
-        List<Button> buttons = getMessage().getButtons();
-        for (int i = 0; i < buttons.size(); i++) {
-            Button current = buttons.get(i);
-            if (getSource().getComponentId().equals(current.getId()))
-                return i;
-        }
-        return -1;
     }
 }

--- a/src/main/java/ofc/bot/handlers/interactions/buttons/contexts/ButtonContext.java
+++ b/src/main/java/ofc/bot/handlers/interactions/buttons/contexts/ButtonContext.java
@@ -1,8 +1,8 @@
 package ofc.bot.handlers.interactions.buttons.contexts;
 
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import ofc.bot.handlers.interactions.EntityContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,7 +22,7 @@ public class ButtonContext extends EntityContext<Button, ButtonContext> {
 
     @Override
     public String getId() {
-        return getEntity().getId();
+        return getEntity().getCustomId();
     }
 
     public static ButtonContext of(ButtonStyle style, String label, Emoji emoji) {

--- a/src/main/java/ofc/bot/handlers/interactions/commands/responses/InteractionResponseBuilder.java
+++ b/src/main/java/ofc/bot/handlers/interactions/commands/responses/InteractionResponseBuilder.java
@@ -1,11 +1,13 @@
 package ofc.bot.handlers.interactions.commands.responses;
 
+import net.dv8tion.jda.api.components.MessageTopLevelComponent;
+import net.dv8tion.jda.api.components.MessageTopLevelComponentUnion;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.actionrow.ActionRowChildComponent;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.exceptions.ErrorHandler;
 import net.dv8tion.jda.api.interactions.InteractionHook;
-import net.dv8tion.jda.api.interactions.components.ItemComponent;
-import net.dv8tion.jda.api.interactions.components.LayoutComponent;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
@@ -83,6 +85,11 @@ public class InteractionResponseBuilder implements InteractionResponseData {
         return this;
     }
 
+    public InteractionResponseBuilder setUsingComponentsV2(boolean flag) {
+        builder.useComponentsV2(flag);
+        return this;
+    }
+
     public InteractionResponseBuilder setAllowedMentions(Collection<Message.MentionType> mentions) {
         builder.setAllowedMentions(mentions);
         return this;
@@ -107,23 +114,23 @@ public class InteractionResponseBuilder implements InteractionResponseData {
         return this;
     }
 
-    public InteractionResponseBuilder setComponents(LayoutComponent... components) {
+    public InteractionResponseBuilder setComponents(MessageTopLevelComponent... components) {
         builder.setComponents(components);
         return this;
     }
 
-    public InteractionResponseBuilder setComponents(List<? extends LayoutComponent> components) {
+    public InteractionResponseBuilder setComponents(List<? extends MessageTopLevelComponent> components) {
         builder.setComponents(components);
         return this;
     }
 
-    public InteractionResponseBuilder setActionRow(List<? extends ItemComponent> components) {
-        builder.setActionRow(components);
+    public InteractionResponseBuilder setActionRows(ActionRowChildComponent... rows) {
+        builder.setComponents(ActionRow.of(List.of(rows)));
         return this;
     }
 
-    public InteractionResponseBuilder setActionRow(ItemComponent... components) {
-        builder.setActionRow(components);
+    public InteractionResponseBuilder setActionRows(List<? extends ActionRowChildComponent> row) {
+        builder.setComponents(ActionRow.of(row));
         return this;
     }
 
@@ -177,8 +184,13 @@ public class InteractionResponseBuilder implements InteractionResponseData {
 
     @NotNull
     @Override
-    public List<LayoutComponent> getComponents() {
+    public List<MessageTopLevelComponentUnion> getComponents() {
         return builder.getComponents();
+    }
+
+    @Override
+    public boolean isUsingComponentsV2() {
+        return builder.isUsingComponentsV2();
     }
 
     @NotNull

--- a/src/main/java/ofc/bot/handlers/interactions/modals/contexts/ModalContext.java
+++ b/src/main/java/ofc/bot/handlers/interactions/modals/contexts/ModalContext.java
@@ -1,8 +1,7 @@
 package ofc.bot.handlers.interactions.modals.contexts;
 
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.text.TextInput;
-import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.components.label.Label;
+import net.dv8tion.jda.api.modals.Modal;
 import ofc.bot.handlers.interactions.EntityContext;
 
 import java.util.List;
@@ -14,27 +13,23 @@ public class ModalContext extends EntityContext<Modal, ModalContext> {
         super(modal);
     }
 
-    public static ModalContext of(String customId, String title, List<TextInput> inputs) {
-        List<ActionRow> rows = inputs.stream()
-                .map(ActionRow::of)
-                .toList();
-
+    public static ModalContext of(String customId, String title, List<Label> labels) {
         Modal modal = Modal.create(customId, title)
-                .addComponents(rows)
+                .addComponents(labels)
                 .build();
         return new ModalContext(modal);
     }
 
-    public static ModalContext of(String customId, String title, TextInput... inputs) {
-        return of(customId, title, List.of(inputs));
+    public static ModalContext of(String customId, String title, Label... labels) {
+        return of(customId, title, List.of(labels));
     }
 
-    public static ModalContext of(String title, List<TextInput> inputs) {
-        return of(UUID.randomUUID().toString(), title, inputs);
+    public static ModalContext of(String title, List<Label> labels) {
+        return of(UUID.randomUUID().toString(), title, labels);
     }
 
-    public static ModalContext of(String title, TextInput... inputs) {
-        return of(title, List.of(inputs));
+    public static ModalContext of(String title, Label... labels) {
+        return of(title, List.of(labels));
     }
 
     @Override

--- a/src/main/java/ofc/bot/handlers/paginations/PageItem.java
+++ b/src/main/java/ofc/bot/handlers/paginations/PageItem.java
@@ -49,7 +49,7 @@ public class PageItem<T>{
      * Checks if there are more pages available.
      * <p>
      * Useful when creating
-     * {@link net.dv8tion.jda.api.interactions.components.buttons.Button Button}s
+     * {@link net.dv8tion.jda.api.components.buttons.Button Button}s
      * for interactive pagination.
      *
      * @return {@code true} if there are more pages available,

--- a/src/main/java/ofc/bot/listeners/discord/guilds/messages/LorittaDailySpamBlocker.java
+++ b/src/main/java/ofc/bot/listeners/discord/guilds/messages/LorittaDailySpamBlocker.java
@@ -1,11 +1,11 @@
 package ofc.bot.listeners.discord.guilds.messages;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageReference;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.util.Bot;
 import ofc.bot.util.content.annotations.listeners.DiscordEventHandler;
 
@@ -48,7 +48,7 @@ public class LorittaDailySpamBlocker extends ListenerAdapter {
 
     private Status resolveStatus(Message msg) {
         String content = msg.getContentRaw().toLowerCase();
-        List<Button> buttons = msg.getButtons();
+        List<Button> buttons = msg.getComponentTree().findAll(Button.class);
 
         if (content.contains("já recebeu a sua recompensa")) return Status.COLLECTED;
 

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/BirthdayPageUpdate.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/BirthdayPageUpdate.java
@@ -1,16 +1,15 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.Birthday;
 import ofc.bot.domain.sqlite.repository.BirthdayRepository;
 import ofc.bot.handlers.interactions.AutoResponseType;
+import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.InteractionListener;
 import ofc.bot.handlers.interactions.buttons.contexts.ButtonClickContext;
-import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.responses.states.InteractionResult;
-import ofc.bot.handlers.interactions.commands.responses.states.Status;
 import ofc.bot.util.Scopes;
 import ofc.bot.util.content.annotations.listeners.InteractionHandler;
 import ofc.bot.util.embeds.EmbedFactory;
@@ -34,10 +33,9 @@ public class BirthdayPageUpdate implements InteractionListener<ButtonClickContex
         List<Button> newButtons = EntityContextFactory.createBirthdayListButtons(month);
         MessageEmbed newEmbed = EmbedFactory.embedBirthdayList(birthdays, guild, month);
 
-        ctx.editMessageEmbeds(newEmbed)
-                .setActionRow(newButtons)
-                .queue();
-
-        return Status.OK;
+        return ctx.create()
+                .setEmbeds(newEmbed)
+                .setActionRows(newButtons)
+                .edit();
     }
 }

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/LeaderboardOffsetUpdate.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/LeaderboardOffsetUpdate.java
@@ -1,8 +1,8 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.viewmodels.LeaderboardUser;
 import ofc.bot.handlers.interactions.AutoResponseType;
 import ofc.bot.handlers.interactions.EntityContextFactory;
@@ -32,7 +32,7 @@ public class LeaderboardOffsetUpdate implements InteractionListener<ButtonClickC
 
         return ctx.create()
                 .setEmbeds(newEmbed)
-                .setActionRow(newButtons)
+                .setActionRows(newButtons)
                 .edit();
     }
 }

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/LevelsPageUpdate.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/LevelsPageUpdate.java
@@ -1,15 +1,15 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.commands.slash.levels.LevelsCommand;
 import ofc.bot.domain.sqlite.repository.UserXPRepository;
 import ofc.bot.domain.viewmodels.LevelView;
 import ofc.bot.handlers.interactions.AutoResponseType;
+import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.InteractionListener;
 import ofc.bot.handlers.interactions.buttons.contexts.ButtonClickContext;
-import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.responses.states.InteractionResult;
 import ofc.bot.handlers.interactions.commands.responses.states.Status;
 import ofc.bot.handlers.paginations.PageItem;
@@ -45,7 +45,7 @@ public class LevelsPageUpdate implements InteractionListener<ButtonClickContext>
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(buttons)
+                .setActionRows(buttons)
                 .edit();
     }
 }

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/NamesPageUpdate.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/NamesPageUpdate.java
@@ -1,16 +1,15 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.enums.NameScope;
 import ofc.bot.domain.sqlite.repository.UserNameUpdateRepository;
 import ofc.bot.domain.viewmodels.NamesHistoryView;
 import ofc.bot.handlers.interactions.AutoResponseType;
+import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.InteractionListener;
 import ofc.bot.handlers.interactions.buttons.contexts.ButtonClickContext;
-import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.responses.states.InteractionResult;
 import ofc.bot.handlers.interactions.commands.responses.states.Status;
 import ofc.bot.util.Bot;
@@ -44,12 +43,11 @@ public class NamesPageUpdate implements InteractionListener<ButtonClickContext> 
         Bot.fetchUser(targetId).queue((target) -> {
             MessageEmbed newEmbed = EmbedFactory.embedUsernameUpdates(namesData, guild, target);
 
-            ctx.editMessageEmbeds(newEmbed)
-                    .setComponents(ActionRow.of(newButtons))
-                    .queue();
-
+            ctx.create()
+                    .setEmbeds(newEmbed)
+                    .setActionRows(newButtons)
+                    .edit();
         }, (error) -> ctx.reply(Status.USER_NOT_FOUND));
-
         return Status.OK;
     }
 }

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/ProposalListPagination.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/ProposalListPagination.java
@@ -1,13 +1,13 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.sqlite.repository.MarriageRequestRepository;
 import ofc.bot.domain.viewmodels.ProposalsView;
+import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.InteractionListener;
 import ofc.bot.handlers.interactions.buttons.contexts.ButtonClickContext;
-import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.responses.states.InteractionResult;
 import ofc.bot.handlers.interactions.commands.responses.states.Status;
 import ofc.bot.util.Bot;
@@ -40,7 +40,7 @@ public class ProposalListPagination implements InteractionListener<ButtonClickCo
 
             ctx.create()
                     .setEmbeds(embed)
-                    .setActionRow(buttons)
+                    .setActionRows(buttons)
                     .edit();
         }, (e) -> ctx.reply(Status.USER_NOT_FOUND));
         return Status.OK;

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/TicketsPagination.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/TicketsPagination.java
@@ -1,8 +1,8 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.Main;
 import ofc.bot.domain.entity.SupportTicket;
 import ofc.bot.domain.sqlite.repository.MessageVersionRepository;
@@ -57,9 +57,10 @@ public class TicketsPagination implements InteractionListener<ButtonClickContext
             MessageEmbed embed = EmbedFactory.embedTicketPage(issuer, guild, ticket, users);
             List<Button> buttons = EntityContextFactory.createTicketsButtons(byUser, byStatus, pageIndex, hasMore);
 
-            ctx.editMessageEmbeds(embed)
-                    .setActionRow(buttons)
-                    .queue();
+            ctx.create()
+                    .setEmbeds(embed)
+                    .setActionRows(buttons)
+                    .edit();
         }, (err) -> { // Also ???
             LOGGER.error("We failed to fetch the user who issued ticket {}", ticket.getId(), err);
         });

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/TransactionsPagination.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/TransactionsPagination.java
@@ -1,16 +1,16 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.commands.slash.economy.TransactionsCommand;
 import ofc.bot.domain.entity.BankTransaction;
 import ofc.bot.domain.entity.enums.TransactionType;
 import ofc.bot.handlers.economy.CurrencyType;
 import ofc.bot.handlers.interactions.AutoResponseType;
+import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.InteractionListener;
 import ofc.bot.handlers.interactions.buttons.contexts.ButtonClickContext;
-import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.responses.states.InteractionResult;
 import ofc.bot.handlers.interactions.commands.responses.states.Status;
 import ofc.bot.handlers.paginations.PageItem;
@@ -45,7 +45,7 @@ public class TransactionsPagination implements InteractionListener<ButtonClickCo
 
             ctx.create()
                     .setEmbeds(embed)
-                    .setActionRow(btns)
+                    .setActionRows(btns)
                     .edit();
         }, (err) -> ctx.reply(Status.USER_NOT_FOUND));
         return Status.OK;

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/infractions/DeleteInfraction.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/infractions/DeleteInfraction.java
@@ -1,8 +1,8 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination.infractions;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.commands.slash.moderation.InfractionsCommand;
 import ofc.bot.domain.entity.MemberPunishment;
 import ofc.bot.domain.sqlite.repository.MemberPunishmentRepository;
@@ -73,7 +73,7 @@ public class DeleteInfraction implements InteractionListener<ButtonClickContext>
 
             ctx.create()
                     .setEmbeds(embed)
-                    .setActionRow(btns)
+                    .setActionRows(btns)
                     .edit();
         }, (err) -> ctx.reply(Status.USER_NOT_FOUND));
         return Status.OK;

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/infractions/InfractionsPageUpdate.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/infractions/InfractionsPageUpdate.java
@@ -1,14 +1,14 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination.infractions;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.commands.slash.moderation.InfractionsCommand;
 import ofc.bot.domain.entity.MemberPunishment;
 import ofc.bot.handlers.interactions.AutoResponseType;
+import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.InteractionListener;
 import ofc.bot.handlers.interactions.buttons.contexts.ButtonClickContext;
-import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.handlers.interactions.commands.responses.states.InteractionResult;
 import ofc.bot.handlers.interactions.commands.responses.states.Status;
 import ofc.bot.handlers.paginations.PageItem;
@@ -47,7 +47,7 @@ public class InfractionsPageUpdate implements InteractionListener<ButtonClickCon
 
             ctx.create()
                     .setEmbeds(embed)
-                    .setActionRow(btns)
+                    .setActionRows(btns)
                     .edit();
         }, (err) -> ctx.reply(Status.USER_NOT_FOUND));
         return Status.OK;

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/reminders/DeleteReminder.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/reminders/DeleteReminder.java
@@ -1,8 +1,8 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination.reminders;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.Reminder;
 import ofc.bot.domain.sqlite.repository.ReminderRepository;
 import ofc.bot.handlers.interactions.AutoResponseType;
@@ -58,7 +58,7 @@ public class DeleteReminder implements InteractionListener<ButtonClickContext> {
 
             return ctx.create()
                     .setEmbeds(embed)
-                    .setActionRow(buttons)
+                    .setActionRows(buttons)
                     .edit();
         } catch (DataAccessException e) {
             LOGGER.error("Failed to set reminder {} as expired", reminderId, e);

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/reminders/RemindersPageUpdate.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/pagination/reminders/RemindersPageUpdate.java
@@ -1,8 +1,8 @@
 package ofc.bot.listeners.discord.interactions.buttons.pagination.reminders;
 
+import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import ofc.bot.domain.entity.Reminder;
 import ofc.bot.handlers.interactions.AutoResponseType;
 import ofc.bot.handlers.interactions.EntityContextFactory;
@@ -37,7 +37,7 @@ public class RemindersPageUpdate implements InteractionListener<ButtonClickConte
 
         return ctx.create()
                 .setEmbeds(embed)
-                .setActionRow(buttons)
+                .setActionRows(buttons)
                 .edit();
     }
 }

--- a/src/main/java/ofc/bot/listeners/discord/interactions/buttons/tickets/CloseTicketHandler.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/buttons/tickets/CloseTicketHandler.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.modals.Modal;
 import ofc.bot.handlers.interactions.EntityContextFactory;
 import ofc.bot.listeners.discord.interactions.modals.tickets.TicketCreationHandler;
 import ofc.bot.util.content.Staff;

--- a/src/main/java/ofc/bot/listeners/discord/interactions/menus/ChoosableRolesListener.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/menus/ChoosableRolesListener.java
@@ -1,12 +1,12 @@
 package ofc.bot.listeners.discord.interactions.menus;
 
+import net.dv8tion.jda.api.components.selections.SelectOption;
+import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
-import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import ofc.bot.util.content.annotations.listeners.DiscordEventHandler;
 
 import java.util.List;

--- a/src/main/java/ofc/bot/listeners/discord/interactions/modals/ChoosableRolesHandler.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/modals/ChoosableRolesHandler.java
@@ -1,11 +1,12 @@
 package ofc.bot.listeners.discord.interactions.modals;
 
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.selections.SelectMenu;
+import net.dv8tion.jda.api.components.selections.SelectOption;
+import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
-import net.dv8tion.jda.api.interactions.components.selections.SelectOption;
-import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.utils.FileUpload;
 import ofc.bot.handlers.interactions.AutoResponseType;
 import ofc.bot.handlers.interactions.InteractionListener;
@@ -66,7 +67,7 @@ public class ChoosableRolesHandler implements InteractionListener<ModalSubmitCon
 
         chan.sendMessageEmbeds(embed)
                 .setFiles(files)
-                .setActionRow(rolesMenu)
+                .setComponents(ActionRow.of(rolesMenu))
                 .queue();
 
         return ctx.reply(Status.DONE);

--- a/src/main/java/ofc/bot/listeners/discord/interactions/modals/tickets/TicketCreationHandler.java
+++ b/src/main/java/ofc/bot/listeners/discord/interactions/modals/tickets/TicketCreationHandler.java
@@ -1,12 +1,13 @@
 package ofc.bot.listeners.discord.interactions.modals.tickets;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.concrete.Category;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.requests.restaction.ChannelAction;
 import ofc.bot.domain.entity.SupportTicket;
 import ofc.bot.domain.sqlite.repository.SupportTicketRepository;
@@ -95,7 +96,7 @@ public class TicketCreationHandler implements InteractionListener<ModalSubmitCon
 
             TextChannel chan = creation.complete();
             chan.sendMessageEmbeds(initialEmbed)
-                    .addActionRow(CLOSE_TICKET_BUTTON)
+                    .addComponents(ActionRow.of(CLOSE_TICKET_BUTTON))
                     .queue();
 
             return chan;


### PR DESCRIPTION
## Pull Request Etiquette
Discord recently released [Components V2](https://discord.com/developers/docs/change-log#introducing-new-components-for-messages), introducing a new generation of message components with significant API changes.
**JDA 6.0.0** now officially supports this new system, and this PR updates the project accordingly.

### What Changed
This pull request updates 50+ classes across the codebase to align with the new Components V2 standards.
These changes should ensure compatibility with JDA 6 and modern Discord interaction patterns.

